### PR TITLE
Add syntax highlighting to README code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ WARaft is a Raft library in Erlang by WhatsApp. It provides an Erlang implementa
 
 The following code snippet gives a quick glance about how WARaft works. It creates a single-node WARaft cluster and writes and reads a record.
 
-```
+```erlang
 % Setup the WARaft application and the host application
 rr(wa_raft_server).
 application:ensure_all_started(wa_raft).
@@ -38,7 +38,7 @@ wa_raft_acceptor:read(raft_acceptor_test_1, {read, test, key}).
 
 A typical output would look like the following:
 
-```
+```erlang
 1> % Setup the WARaft application and the host application
    rr(wa_raft_server).
 [raft_application,raft_identifier,raft_identity,raft_log,


### PR DESCRIPTION
This PR improves the readability of the README by adding syntax highlighting to code snippets.

before:
<img width="833" alt="Screenshot 2025-03-07 at 13 44 23" src="https://github.com/user-attachments/assets/740a9a3d-54ae-4c44-8db9-55b48cd049f6" />

after:
<img width="833" alt="Screenshot 2025-03-07 at 13 43 55" src="https://github.com/user-attachments/assets/d5062d44-6ac7-4718-bc70-c5bb2baea20f" />
